### PR TITLE
feat: use proper dependency on public resource

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ env:
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches:
-      - '!master'   # master handled in release.yaml
+    branches0ignore:
+      - 'master'   # master handled in release.yaml
 
 
 jobs:
@@ -37,8 +37,6 @@ jobs:
         uses: actions/checkout@v4
         # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
         # https://github.com/bazelbuild/bazel/issues/11062
-      -
-        run: bazel build //...
       -
         run: bazel test //... --test_output=errors --test_summary=detailed
       -

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,13 +8,7 @@ bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_synology")
-
-# When reusing for your own project, don't use this local-override
-local_path_override(
-    module_name = "rules_synology",
-    path = "../rules_synology",
-)
+bazel_dep(name = "rules_synology", version="0.0.2")
 
 #http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 

--- a/spk/minecraft-bedrock/BUILD.bazel
+++ b/spk/minecraft-bedrock/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg/private/tar:tar.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_tar")
-load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "docker_project", "images", "info_file", "maintainer", "privilege_config", "protocol_file", "resource_config", "service_config", docker_compose = "fn_docker_compose")
+load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "docker_project", "images", "info_file", "maintainer", "privilege_config", "protocol_file", "resource_config", "service_config", "docker_compose")
 
 # This is the "project" in a docker-project sense: the name of the docker-compose subdir is the
 # name of the multi-container project described in the "compose" file


### PR DESCRIPTION
On proper expose of the `rules_synology` resource, switch to proper version-tracked import.